### PR TITLE
Fix up meyda input mismatch issue

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -41,8 +41,6 @@ class Audio {
 
     this.fallBackAudio =  $('#fallBackAudio');
 
-    // this.onlineContext = new AudioContext();
-
     this.initSrcNode();
 
     this.initDownSampleNode();

--- a/meyda.js
+++ b/meyda.js
@@ -700,7 +700,6 @@ var Meyda = {
   windowingFunction: 'hanning',
   featureExtractors: __WEBPACK_IMPORTED_MODULE_1__featureExtractors__,
   EXTRACTION_STARTED: false,
-  RECEIVED_DATA: false,
   numberOfMFCCCoefficients: 40,
   _featuresToExtract: [],
   windowing: __WEBPACK_IMPORTED_MODULE_0__utilities__["a" /* applyWindow */],
@@ -741,13 +740,6 @@ var Meyda = {
       this.signal = __WEBPACK_IMPORTED_MODULE_0__utilities__["f" /* arrayToTyped */](signal);
     } else {
       this.signal = signal;
-    }
-
-    if (this.signal.every(function(elem) {return elem == 0}) && !this.RECEIVED_DATA) {
-      // drop all zero entries at the begining
-      return [];
-    } else {
-      this.RECEIVED_DATA = true;
     }
 
     var preparedSignal = prepareSignalWithSpectrum(signal, this.windowingFunction, this.bufferSize);
@@ -1830,7 +1822,6 @@ var MeydaAnalyzer = function () {
     value: function start(features) {
       this._m._featuresToExtract = features || this._m._featuresToExtract;
       this._m.EXTRACTION_STARTED = true;
-      this._m.RECEIVED_DATA = false;
     }
   }, {
     key: 'stop',


### PR DESCRIPTION
As I mentioned previously, the issue was that input that meyda was getting mismatched with what I passed in as an input.

The reason was that destination node of Meyda is speaker which has sample rate of browser (44100).
each event of data flow within WebAudioAPI is initiated by the destination node and even though we pass in 16000 as sample rate for Meyda, it only used it for computation not to change behaviour of the data flow.

Solution was to create separate context (offline) which is created with 16000 sample rate.

I have verified that honkling now works with both mic and audio with very high prediction accuracy!!
